### PR TITLE
refactor(cli): correct template copy logic and add staging command

### DIFF
--- a/bin/dokugent.js
+++ b/bin/dokugent.js
@@ -50,6 +50,20 @@ program
     });
   });
 
+
+program
+  .command('stage')
+  .description('Stage a human-readable instruction review before compilation')
+  .option('--scope <folder>', 'Target folder inside .dokugent to stage')
+  .option('--with-checklists', 'Include starter checklist content')
+  .option('--protocols <items>', 'Comma-separated protocol folders or "all"')
+  .action(async (options) => {
+    const scope = options.scope || '.dokugent';
+
+    const { stageReview } = await import('../lib/core/stageBlueprint.js');
+    stageReview({ scope, withChecklists: options.withChecklists, protocols: options.protocols });
+  });
+
 program
   .command('compile')
   .description('Compile an agent briefing from existing .dokugent/ files')

--- a/lib/config/expected-files.js
+++ b/lib/config/expected-files.js
@@ -2,43 +2,42 @@
 export const expectedDefaultFiles = [
   'README.md',
   'agent-instructions.md',
-  'devops/dependency-policy.md',
   'projects.md'
 ];
 
 export const docBlueprints = {
   default: [
-    'changelog/v0.1.md',
-    'db-schema/migrations.md',
-    'db-schema/models.md',
-    'db-schema/relationships.md',
-    'db-schema/seed-data.md',
-    'design-system/components.md',
-    'design-system/tokens.md',
-    'devops/dependency-log.md',
-    'devops/deploy.md',
-    'devops/setup.md',
-    'marketing/launch-checklist.md',
-    'mvc/controllers.md',
-    'mvc/models.md',
-    'mvc/routes.md',
-    'mvc/views.md',
-    'qa/checklist.md',
-    'qa/edge-cases.md',
-    'security/auth.md',
-    'tech-seo/meta.md',
-    'tech-seo/sitemap.md',
-    'testing/manual.md',
-    'testing/unit.md',
-    'ux/flows.md',
-    'ux/personas.md'
+    'protocols/changelog/v0.1.md',
+    'protocols/db-schema/migrations.md',
+    'protocols/db-schema/models.md',
+    'protocols/db-schema/relationships.md',
+    'protocols/db-schema/seed-data.md',
+    'protocols/design-system/components.md',
+    'protocols/design-system/tokens.md',
+    'protocols/devops/dependency-log.md',
+    'protocols/devops/deploy.md',
+    'protocols/devops/setup.md',
+    'protocols/marketing/launch-checklist.md',
+    'protocols/mvc/controllers.md',
+    'protocols/mvc/models.md',
+    'protocols/mvc/routes.md',
+    'protocols/mvc/views.md',
+    'protocols/qa/checklist.md',
+    'protocols/qa/edge-cases.md',
+    'protocols/security/auth.md',
+    'protocols/tech-seo/meta.md',
+    'protocols/tech-seo/sitemap.md',
+    'protocols/testing/manual.md',
+    'protocols/testing/unit.md',
+    'protocols/ux/flows.md',
+    'protocols/ux/personas.md'
   ],
 
   minimal: [
-    'ux/flows.md',
-    'ux/personas.md',
-    'mvc/controllers.md',
-    'db-schema/models.md'
+    'protocols/ux/flows.md',
+    'protocols/ux/personas.md',
+    'protocols/mvc/controllers.md',
+    'protocols/db-schema/models.md'
   ],
 
   research: [
@@ -46,6 +45,6 @@ export const docBlueprints = {
     'hypotheses/main.md',
     'experiment/setup.md',
     'results/findings.md',
-    'qa/edge-cases.md'
+    'protocols/qa/edge-cases.md'
   ]
 };

--- a/lib/config/scaffold-groups.js
+++ b/lib/config/scaffold-groups.js
@@ -1,17 +1,18 @@
 export const folderGroups = {
   core: {
     'changelog': ['v0.1.md'],
-    'db-schema': ['migrations.md', 'models.md', 'relationships.md', 'seed-data.md'],
-    'design-system': ['components.md', 'tokens.md'],
-    'mvc': ['controllers.md', 'models.md', 'views.md', 'routes.md'],
-    'ux': ['flows.md', 'personas.md']
+    'protocols/db-schema': ['migrations.md', 'models.md', 'relationships.md', 'seed-data.md'],
+    'protocols/design-system': ['components.md', 'tokens.md'],
+    'protocols/devops': ['dependency-policy.md'],
+    'protocols/mvc': ['controllers.md', 'models.md', 'views.md', 'routes.md'],
+    'protocols/ux': ['flows.md', 'personas.md']
   },
   addons: {
-    'devops': ['dependency-log.md', 'dependency-policy.md', 'deploy.md', 'setup.md'],
-    'marketing': ['launch-checklist.md'],
-    'qa': ['checklist.md', 'edge-cases.md'],
-    'security': ['auth.md'],
-    'tech-seo': ['meta.md', 'sitemap.md'],
-    'testing': ['manual.md', 'unit.md']
+    'protocols/devops': ['dependency-log.md', 'deploy.md', 'setup.md'],
+    'protocols/marketing': ['launch-checklist.md'],
+    'protocols/qa': ['checklist.md', 'edge-cases.md'],
+    'protocols/security': ['auth.md'],
+    'protocols/tech-seo': ['meta.md', 'sitemap.md'],
+    'protocols/testing': ['manual.md', 'unit.md']
   }
 };

--- a/lib/core/scaffoldAgentBriefing.js
+++ b/lib/core/scaffoldAgentBriefing.js
@@ -1,5 +1,3 @@
-
-
 import fs from 'fs-extra';
 import path from 'path';
 import yaml from 'js-yaml';

--- a/lib/core/scaffoldApp.js
+++ b/lib/core/scaffoldApp.js
@@ -25,44 +25,36 @@ function scaffoldTemplates(scope, options) {
 
     files.forEach(file => {
       const filePath = path.join(fullPath, file);
-      const templatePath = path.join(templateBase, folder, file);
-      const shouldWrite = options.force || !fs.existsSync(filePath);
+      const templatePath = path.join(templateBase, path.basename(folder), file);
 
-      if (!shouldWrite) {
-        skippedFiles.push(`${folder}/${file}`);
-        return;
-      }
+      if (fs.existsSync(templatePath)) {
+        const shouldWrite = options.force || !fs.existsSync(filePath);
 
-      if (fs.existsSync(filePath) && options.backup) {
-        fs.copyFileSync(filePath, `${filePath}.bak`);
-      }
+        if (!shouldWrite) {
+          skippedFiles.push(`${folder}/${file}`);
+          return;
+        }
 
-      if (options.withChecklists && fs.existsSync(templatePath)) {
-        if (fs.existsSync(filePath)) {
-          if (!options.force) {
-            skippedFiles.push(`${folder}/${file}`);
-            return;
-          }
-
-          if (options.backup) {
-            fs.copyFileSync(filePath, `${filePath}.bak`);
-            console.log(`📦 Backup created: ${folder}/${file}.bak`);
-          }
+        if (fs.existsSync(filePath) && options.backup) {
+          fs.copyFileSync(filePath, `${filePath}.bak`);
+          console.log(`📦 Backup created: ${folder}/${file}.bak`);
         }
 
         const content = fs.readFileSync(templatePath, 'utf-8');
         fs.writeFileSync(filePath, content);
-        console.log(`📋 Created from checklist: ${folder}/${file}`);
+        console.log(`📋 Created from template: ${folder}/${file}`);
       } else {
         fs.writeFileSync(filePath, '');
-        console.log(`📄 Created: ${folder}/${file}`);
+        console.log(`📄 Created empty: ${folder}/${file}`);
       }
     });
   });
 
   expectedDefaultFiles.forEach(templateRelPath => {
     const src = path.resolve(templateBase, templateRelPath);
-    const relativeDest = templateRelPath.replace(/^presets\/templates\//, '');
+    const relativeDest = templateRelPath.startsWith('protocols/')
+      ? path.join('protocols', templateRelPath.replace(/^protocols\//, ''))
+      : templateRelPath;
     const dest = path.resolve(rootPath, relativeDest);
     fs.ensureDirSync(path.dirname(dest));
 

--- a/lib/core/stageBlueprint.js
+++ b/lib/core/stageBlueprint.js
@@ -1,0 +1,47 @@
+import fs from 'fs-extra';
+import path from 'path';
+
+// options: { scope: string, protocols: string }
+export function stageReview(options) {
+  console.log('🛠 Running stageReview with options:', options);
+  const dokugentPath = path.join(process.cwd(), options.scope);
+  const reviewPath = path.join(dokugentPath, 'staging');
+  const reviewFile = path.join(reviewPath, 'review.md');
+
+  fs.ensureDirSync(reviewPath);
+
+  let foldersToInclude = [];
+
+  if (options.protocols === 'all') {
+    const protocolsDir = path.join(dokugentPath, 'protocols');
+    if (fs.existsSync(protocolsDir)) {
+      foldersToInclude = fs.readdirSync(protocolsDir)
+        .filter((f) => fs.statSync(path.join(protocolsDir, f)).isDirectory())
+        .map((f) => path.join('protocols', f));
+    }
+  } else if (typeof options.protocols === 'string') {
+    foldersToInclude = options.protocols.split(',').map((f) => path.join('protocols', f.trim()));
+  }
+
+  const contentLines = [`# Review for ${options.scope}`, ''];
+
+  foldersToInclude.forEach((folder) => {
+    const folderPath = path.join(dokugentPath, folder);
+    if (!fs.existsSync(folderPath)) return;
+
+    contentLines.push(`## ${folder}`);
+    const files = fs.readdirSync(folderPath);
+    files.forEach((file) => {
+      const filePath = path.join(folderPath, file);
+      if (fs.statSync(filePath).isFile()) {
+        const data = fs.readFileSync(filePath, 'utf-8');
+        contentLines.push(`### ${file}\n\n${data.trim()}\n`);
+      }
+    });
+  });
+
+  const fullContent = contentLines.join('\n\n');
+  fs.writeFileSync(reviewFile, fullContent, 'utf-8');
+
+  console.log(`✅ Staging review written to: ${reviewFile}`);
+}

--- a/roadmap.md
+++ b/roadmap.md
@@ -18,6 +18,8 @@ This document outlines the final steps before we ship Dokugent as a public beta.
   - `mvc/controllers.md`, `mvc/models.md`, `mvc/views.md`, `mvc/routes.md`
   - `agent-briefings/claude.md`, `agent-briefings/codex.md`
 - README updated with usage, customization tips, and About context
+- CLI renamed to Dokugent
+- --custom flag added for user-defined scaffold folders
 
 ---
 
@@ -34,15 +36,29 @@ This document outlines the final steps before we ship Dokugent as a public beta.
 - [ ] `tech-seo/sitemap.md`
 - [ ] `marketing/launch-checklist.md`
 
+### Agentic Safety Features
+
+- [ ] Add a staging layer for human-readable instruction review
+- [ ] Compile immutable, versioned blueprints post-approval
+- [ ] Support agent-specific output templates (OpenAI, LangChain, etc.)
+- [ ] Hash and embed metadata in compiled instructions
+- [ ] Include human + machine readable formats in output bundle
+- [ ] Document alignment with Microsoft's AI failure mode taxonomy
+- [ ] Optional signature/approval field in blueprint metadata
+
 ### CLI & Project Polish
 
 - [ ] Add a `dokugent help` command
+- [X] Enforce blueprint.md for --custom scaffolds
+- [X] Finalize tag chaining support (v1)
 - [ ] Add support for `.dokugentrc` config overrides
 - [ ] Add optional footer signature for agent-briefings
 - [ ] Improve logging and token efficiency feedback
+- [X] Document easter eggs ('marites', 'secrets') for fun and transparency
 - [ ] Create a `tag-protocol.md` reference for Doku Tags
 - [ ] Add more `examples/` (e.g. grading-system.md, open-llm-awareness.md)
 - [ ] Update README with Doku Tag explanation and usage
+- [X] Clarify license intent and boundaries (DONE)
 - [ ] Optional postinstall message
 
 ---


### PR DESCRIPTION
- Refactored scaffold logic to resolve protocol-prefixed output while sourcing from non-prefixed templates
- Fixed bug where files were created empty despite valid templates in presets
- Preserved --backup and --force flags during write
- Added 'stage' command to compile a human-readable review.md from scaffolded files
- Defaulted --scope to .dokugent and added --protocols flag support