### PR TITLE
feat(cli): add SHA validation, keygen, and compile cert gating

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,15 +48,39 @@ dokugent scaffold --custom=ai-labs
 
 ## 🛠️ CLI Commands
 
+### scaffold
+  --force            Overwrite existing files
+  --backup           Create .bak backups before overwriting
+  --with-checklists  Include checklist-enhanced templates
+  --custom=<folder>  Create an empty folder inside .dokugent/ with the given name
+
+### stage
+  --scope <folder>   Target folder to stage (defaults to .dokugent)
+  --protocols <list> Comma-separated protocol folders or "all"
+
+### keygen
+  --name <string>    Identity used to label public key metadata
+
+### certify
+  --key <path>       Path to private key for certification
+
+### compile
+  --llm <agent>      Agent to compile briefing for
+  --prod             Enforce SHA + signature verification from review.cert
+  --dev              Compile from llm-load.yml (for isolated dev testing)
+
+## 🧪 Examples
+
 ```bash
-# Scaffold core structure
 dokugent scaffold core
-
-# Add checklists (optional)
-dokugent scaffold core --with-checklists
-
-# Enable safe overwrites
-dokugent scaffold core --force --backup
+dokugent scaffold core --with-checklists --backup
+dokugent scaffold --custom=ai-labs
+dokugent stage --protocols=all
+dokugent stage --protocols=qa,ux
+dokugent keygen --name carmelyne@kinderbytes.com
+dokugent certify --key .dokugent/keys/id_doku_priv.pem
+dokugent compile --llm=codex --prod
+dokugent compile --llm=codex --dev
 ```
 
 ### Tips & Customization
@@ -105,6 +129,8 @@ Which output:
 - `--force` and `--backup` to safely overwrite files
 - CLI tested with Claude, Codex, and GPT agents
 - Blueprint-ready for use in multi-agent LLM workflows
+- Cryptographic certification of instructions via RSA keypair
+- `.gitignore` scaffolding to protect private keys and certs
 
 ## 🤖 Supported LLMs
 

--- a/lib/core/certifyBlueprint.js
+++ b/lib/core/certifyBlueprint.js
@@ -1,0 +1,68 @@
+import fs from 'fs-extra';
+import path from 'path';
+import crypto from 'crypto';
+
+export function certifyBlueprint(options) {
+  const { scope = '.dokugent', key } = options;
+
+  const reviewPath = path.join(process.cwd(), scope, 'staging', 'review.md');
+  const certPath = path.join(process.cwd(), scope, 'certs', 'review.cert');
+
+  if (!fs.existsSync(reviewPath)) {
+    console.error(`❌ review.md not found at ${reviewPath}`);
+    process.exit(1);
+  }
+
+  if (!fs.existsSync(key)) {
+    console.error(`❌ Private key not found at ${key}`);
+    process.exit(1);
+  }
+
+  const reviewContent = fs.readFileSync(reviewPath, 'utf-8');
+  const hash = crypto.createHash('sha256').update(reviewContent).digest('hex');
+
+  const privateKey = fs.readFileSync(key, 'utf-8');
+  const signer = crypto.createSign('RSA-SHA256');
+  signer.update(hash);
+  signer.end();
+  const signature = signer.sign(privateKey, 'base64');
+
+  const metadata = {
+    cert_version: 1,
+    signed_by: path.basename(key), // placeholder for signer ID
+    signed_at: new Date().toISOString(),
+    review_hash: hash,
+    signature
+  };
+
+  fs.ensureDirSync(path.dirname(certPath));
+  fs.writeFileSync(certPath, JSON.stringify(metadata, null, 2), 'utf-8');
+
+  console.log(`✅ Certified review.md. Output written to ${certPath}`);
+}
+
+import { execSync } from 'child_process';
+
+export function generateKeypair(name) {
+  const keysDir = path.join(process.cwd(), '.dokugent', 'keys');
+  const privKeyPath = path.join(keysDir, 'id_doku_priv.pem');
+  const pubKeyPath = path.join(keysDir, 'id_doku_pub.pem');
+
+  fs.ensureDirSync(keysDir);
+
+  console.log(`🔐 Generating RSA keypair for ${name}...`);
+
+  try {
+    execSync(`openssl genpkey -algorithm RSA -out ${privKeyPath} -pkeyopt rsa_keygen_bits:2048`);
+    execSync(`openssl rsa -pubout -in ${privKeyPath} -out ${pubKeyPath}`);
+  } catch (err) {
+    console.error('❌ Failed to generate keypair:', err.message);
+    process.exit(1);
+  }
+
+  const signersFile = path.join(keysDir, 'signers.yml');
+  const signerEntry = `- id: ${name}\n  pubkey_file: id_doku_pub.pem\n  created_at: ${new Date().toISOString()}\n`;
+
+  fs.appendFileSync(signersFile, signerEntry);
+  console.log(`✅ Keypair created at ${keysDir}`);
+}

--- a/lib/core/compileBriefing.js
+++ b/lib/core/compileBriefing.js
@@ -1,0 +1,113 @@
+import fs from 'fs-extra';
+import path from 'path';
+import crypto from 'crypto';
+
+// Compile agent briefing, with optional certificate verification
+export async function compileBriefing(agent) {
+  const dokugentPath = path.join(process.cwd(), '.dokugent');
+  const reviewPath = path.join(dokugentPath, 'staging', 'review.md');
+  const certPath = path.join(dokugentPath, 'certs', 'review.cert');
+  const pubKeyPath = path.join(dokugentPath, 'keys', 'id_doku_pub.pem');
+
+  // Require cert mode
+  const certRequired = process.argv.includes('--prod');
+  const devMode = process.argv.includes('--dev');
+
+  let cert = null;
+
+  if (certRequired) {
+    if (!fs.existsSync(reviewPath) || !fs.existsSync(certPath) || !fs.existsSync(pubKeyPath)) {
+      console.error('❌ Missing review.md, review.cert, or public key for verification');
+      process.exit(1);
+    }
+
+    const reviewContent = fs.readFileSync(reviewPath, 'utf-8');
+    const currentHash = crypto.createHash('sha256').update(reviewContent).digest('hex');
+
+    cert = JSON.parse(fs.readFileSync(certPath, 'utf-8'));
+    console.log('🧾 Expected hash:', cert.review_hash);
+    console.log('📄 Current hash: ', currentHash);
+
+    if (cert.review_hash !== currentHash) {
+      console.error('❌ review.md has changed since certification – hash mismatch');
+      process.exit(1);
+    }
+
+    const verifier = crypto.createVerify('RSA-SHA256');
+    verifier.update(currentHash);
+    verifier.end();
+
+    const pubKey = fs.readFileSync(pubKeyPath, 'utf-8');
+    const isValid = verifier.verify(pubKey, cert.signature, 'base64');
+
+    if (!isValid) {
+      console.error('❌ Signature verification failed – review.md may have been tampered with');
+      process.exit(1);
+    }
+
+    console.log('🔐 Certificate verified: hash and signature match.');
+  }
+
+  // Fallback if not requiring cert, read review.md directly
+  const reviewContent = fs.readFileSync(reviewPath, 'utf-8');
+
+  const frontmatterMatch = reviewContent.match(/^---\n([\s\S]*?)\n---\n/);
+  let reviewFrontmatter = {};
+  let contentWithoutFrontmatter = reviewContent;
+
+  if (frontmatterMatch) {
+    const yaml = await import('js-yaml');
+    reviewFrontmatter = yaml.load(frontmatterMatch[1]);
+    contentWithoutFrontmatter = reviewContent.slice(frontmatterMatch[0].length);
+  }
+
+  const compiledDir = path.join(dokugentPath, 'compiled-agent-specs');
+  const compiledFile = path.join(compiledDir, `${agent}.md`);
+
+  fs.ensureDirSync(compiledDir);
+
+  const compiledHash = crypto.createHash('sha256').update(reviewContent).digest('hex');
+  const timestamp = new Date().toISOString();
+
+  const combinedFrontmatter = {
+    ...reviewFrontmatter,
+    compiled_by: 'dokugent@cli',
+    compiled_at: timestamp,
+    compiled_sha: compiledHash,
+    from_review_sha: certRequired ? cert.review_hash : 'n/a'
+  };
+
+  const yaml = await import('js-yaml');
+  const frontmatterBlock = `---\n${yaml.dump(combinedFrontmatter)}---\n\n`;
+  const compiledContent = `${frontmatterBlock}${contentWithoutFrontmatter}`;
+
+  fs.writeFileSync(compiledFile, compiledContent, 'utf-8');
+
+  const tokenEstimate = Math.round(reviewContent.split(/\s+/).length * 1.5);
+  console.log(`🧠 Agent briefing compiled: ${path.relative(process.cwd(), compiledFile)}`);
+  console.log(`📊 Estimated token size: ~${tokenEstimate} tokens`);
+
+  if (devMode) {
+    const llmLoadPath = path.join(dokugentPath, 'llm-load.yml');
+    if (!fs.existsSync(llmLoadPath)) {
+      console.error('❌ review.md not found and no llm-load.yml available. Aborting.');
+      process.exit(1);
+    }
+
+    const yaml = await import('js-yaml');
+    const llmLoad = yaml.load(fs.readFileSync(llmLoadPath, 'utf-8'));
+    const lines = [];
+
+    for (const filePath of llmLoad) {
+      const absPath = path.join(dokugentPath, 'protocols', filePath);
+      if (fs.existsSync(absPath)) {
+        const content = fs.readFileSync(absPath, 'utf-8');
+        lines.push(`### ${filePath}\n\n${content.trim()}`);
+      }
+    }
+
+    const content = lines.join('\n\n');
+    fs.writeFileSync(compiledFile, content, 'utf-8');
+    console.log('🧪 Dev compile from llm-load.yml completed.');
+  }
+}

--- a/lib/core/scaffoldApp.js
+++ b/lib/core/scaffoldApp.js
@@ -14,6 +14,7 @@ function scaffoldTemplates(scope, options) {
   const templateBase = path.resolve(__dirname, '../../presets/templates');
   const folders = folderGroups[scope];
 
+
   if (!folders) {
     console.error(`❌ Unknown scope: ${scope}`);
     return;
@@ -78,6 +79,14 @@ function scaffoldTemplates(scope, options) {
     fs.copyFileSync(src, dest);
     console.log(`📋 Copied default file: ${relativeDest}`);
   });
+
+  // Copy .gitignore from template if present
+  const gitignoreSrc = path.join(templateBase, '.gitignore');
+  const gitignoreDest = path.join(rootPath, '.gitignore');
+  if (fs.existsSync(gitignoreSrc)) {
+    fs.copyFileSync(gitignoreSrc, gitignoreDest);
+    console.log('📋 Copied template: .gitignore');
+  }
 
   if (skippedFiles.length > 0) {
     if (skippedFiles.length > 3) {
@@ -191,42 +200,4 @@ function scaffoldApp(scope = 'core', options = {}) {
   console.log('✅ Finished scaffoldTemplates.');
 }
 
-export { scaffoldApp, compileBriefing };
-function compileBriefing(llm, options = {}) {
-  const rootPath = path.resolve('.dokugent');
-  const llmLoadPath = path.join(rootPath, 'llm-load.yml');
-  const outputPath = path.join(rootPath, 'compiled-agent-specs', `${llm}.md`);
-
-  if (!fs.existsSync(llmLoadPath)) {
-    console.warn(`❗ Missing llm-load.yml. Cannot compile agent briefing without file list.`);
-    return;
-  }
-
-  const yamlData = yaml.load(fs.readFileSync(llmLoadPath, 'utf-8'));
-  const fileList = Array.isArray(yamlData) ? yamlData : yamlData?.files;
-
-  if (!Array.isArray(fileList)) {
-    console.warn(`❗ Invalid format in llm-load.yml. Expected an array of file paths.`);
-    return;
-  }
-
-  const filesToCombine = fileList
-    .map(relPath => path.resolve(rootPath, relPath))
-    .filter(fs.existsSync);
-
-  if (filesToCombine.length === 0) {
-    console.warn(`❗ No valid files found to include in agent briefing.`);
-    return;
-  }
-
-  const combined = filesToCombine
-    .map(file => fs.readFileSync(file, 'utf-8').trim())
-    .join('\n\n---\n\n');
-
-  fs.ensureDirSync(path.dirname(outputPath));
-  fs.writeFileSync(outputPath, combined);
-
-  console.log(`🧠 Agent briefing compiled: compiled-agent-specs/${llm}.md`);
-  const tokenSize = combined.length / 4;
-  console.log(`📊 Estimated token size: ~${Math.round(tokenSize)} tokens`);
-}
+export { scaffoldApp };

--- a/lib/core/stageBlueprint.js
+++ b/lib/core/stageBlueprint.js
@@ -40,6 +40,11 @@ export function stageReview(options) {
     });
   });
 
+  const timestamp = new Date().toISOString();
+  const frontmatter = `---\nreviewed_by: ${process.env.USER || 'unknown'}\nreviewed_at: ${timestamp}\nsha_signed: null\n---\n`;
+
+  contentLines.unshift(frontmatter);
+
   const fullContent = contentLines.join('\n\n');
   fs.writeFileSync(reviewFile, fullContent, 'utf-8');
 

--- a/lib/help/helpText.js
+++ b/lib/help/helpText.js
@@ -6,22 +6,49 @@ Usage:
   dokugent scaffold <scope> [--force] [--backup] [--with-checklists]
   dokugent scaffold --custom=<folder>
   dokugent compile --llm=<codex|claude>
+  dokugent stage [--scope <folder>] [--protocols <list>]
+  dokugent certify --key <path>
 
 Commands:
   scaffold           Scaffold .dokugent folder based on scope (core, qa, addons, etc.)
+  stage              Generate a staging review.md from .dokugent protocols
+  keygen             Generate a private/public RSA keypair for signing certifications
+  certify            Sign review.md with private key and output tamper-checkable .cert
   compile            Compile an agent briefing from .dokugent/ files
 
 Options:
-  --force            Overwrite existing files
-  --backup           Create .bak backups before overwriting
-  --with-checklists  Include checklist-enhanced templates
-  --custom=<folder>  Create an empty folder inside .dokugent/ with the given name
-  --help             Show this help message
+
+  scaffold:
+    --force            Overwrite existing files
+    --backup           Create .bak backups before overwriting
+    --with-checklists  Include checklist-enhanced templates
+    --custom=<folder>  Create an empty folder inside .dokugent/ with the given name
+
+  stage:
+    --scope <folder>   Target folder to stage (defaults to .dokugent)
+    --protocols <list> Comma-separated protocol folders or "all"
+
+  certify:
+    --key <path>       Path to private key for certification
+
+  compile:
+    --llm <agent>      Agent to compile briefing for
+    --prod             Enforce SHA + signature verification from review.cert
+    --dev              Compile from llm-load.yml (for isolated dev testing)
+
+  help:
+    --help             Show this help message
 
 Examples:
   dokugent scaffold core --with-checklists --backup
   dokugent scaffold --custom=ai-labs
   dokugent compile --llm=codex
+  dokugent stage --protocols=all
+  dokugent stage --protocols=qa,ux
+  dokugent keygen --name carmelyne@kinderbytes.com
+  dokugent certify --key .dokugent/keys/id_doku_priv.pem
+  dokugent compile --llm=codex --prod
+  dokugent compile --llm=codex --dev
 
 Learn more:
   🧠 Agent briefings use structured Doku Tags like @document_analysis to guide LLM behavior.

--- a/presets/templates/.gitignore
+++ b/presets/templates/.gitignore
@@ -1,0 +1,13 @@
+# 🔐 Never commit signer private keys
+# Ignore all keys by default
+keys/*
+
+# Allow public key to be committed
+!keys/id_doku_pub.pem
+
+# ⛔️ Certs may contain sensitive signing info
+certs/
+
+# 🧪 Local build artifacts
+staging/
+compiled-agent-specs/

--- a/roadmap.md
+++ b/roadmap.md
@@ -20,6 +20,7 @@ This document outlines the final steps before we ship Dokugent as a public beta.
 - README updated with usage, customization tips, and About context
 - CLI renamed to Dokugent
 - --custom flag added for user-defined scaffold folders
+- Add a staging layer for human-readable instruction review
 
 ---
 
@@ -38,8 +39,7 @@ This document outlines the final steps before we ship Dokugent as a public beta.
 
 ### Agentic Safety Features
 
-- [ ] Add a staging layer for human-readable instruction review
-- [ ] Compile immutable, versioned blueprints post-approval
+- [X] Compile immutable, versioned blueprints post-approval
 - [ ] Support agent-specific output templates (OpenAI, LangChain, etc.)
 - [ ] Hash and embed metadata in compiled instructions
 - [ ] Include human + machine readable formats in output bundle


### PR DESCRIPTION
- Introduced `--prod` and `--dev` flags to `compile` command
- Enforced SHA hash + RSA signature checks via `review.cert`
- Added `keygen` command to generate .pem keys for signing
- Compiled agent specs now include merged frontmatter metadata
- `stage` now auto-generates review.md with timestamped frontmatter
- Updated helpText and README to reflect new commands and flags