### PR TITLE
feat(plan): add plan command with dual file generation and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ dokugent wizard
 ## 🔧 CLI Commands
 
 - `dokugent init` — scaffolds `.dokugent` folder structure and default files
-- `dokugent wizard` — interactively configures agent type, tools, and goals
+- `dokugent wizard` — interactively configures agent or app type, tools, and sets up project files
 - `dokugent plan` — defines the agent’s high-level steps or capabilities
 - `dokugent conventions` — describes and enforces documentation structure
 - `dokugent criteria` — defines validation rules, safety thresholds, and constraints

--- a/bin/dokugent.js
+++ b/bin/dokugent.js
@@ -3,6 +3,7 @@ import { program } from 'commander';
 import { initCore } from '../lib/core/init.js';
 import { init as initBlank } from '../lib/core/init.js';
 import { printHelp } from '../lib/help/helpText.js';
+import { runPlan } from '../lib/core/plan.js';
 
 const calledAs = process.argv[1]?.split('/').pop();
 if (calledAs === 'doku') {
@@ -37,6 +38,14 @@ program
   .description('Print help documentation')
   .action(() => {
     printHelp();
+  });
+
+program
+  .command('plan')
+  .description('Create or update plan.md and plan.yaml in the .dokugent/plan folder')
+  .option('--force', 'overwrite existing files without confirmation')
+  .action(async (options) => {
+    await runPlan({ force: options.force || false });
   });
 
 program.parse(process.argv);

--- a/lib/config/cliSpec.js
+++ b/lib/config/cliSpec.js
@@ -10,8 +10,8 @@ export const cliSpec = {
       flags: []
     },
     plan: {
-      description: 'Create or edit plan.md',
-      flags: ['--new', '--from=<file>', '--edit', '--append']
+      description: 'Create or update plan.md and plan.yaml',
+      flags: ['--force']
     },
     conventions: {
       description: 'Manage and validate expected behaviors',
@@ -57,5 +57,9 @@ export const cliSpec = {
       description: 'Generate a private/public key pair for signing',
       flags: ['--name=<id>']
     },
+    fetch: {
+      description: 'Download community-contributed plan, convention, or tool templates',
+      flags: []
+    }
   }
 };

--- a/lib/core/plan.js
+++ b/lib/core/plan.js
@@ -1,0 +1,56 @@
+/**
+ * Creates or updates a Dokugent agent plan.
+ * Generates both a human-readable plan.md and machine-readable plan.yaml.
+ * Used to define the agent’s role, reasoning steps, and supported tools.
+ * Supports --force to overwrite existing files with backups.
+ */
+
+import fs from 'fs-extra';
+import path from 'path';
+import { writeWithBackup } from '../utils/fileWriter.js';
+
+export async function runPlan({ force = false } = {}) {
+  const planDir = path.resolve('.dokugent/plan');
+  await fs.ensureDir(planDir);
+
+  const mdPath = path.join(planDir, 'plan.md');
+  const yamlPath = path.join(planDir, 'plan.yaml');
+
+  const planMdContent = `# PLAN.md
+
+## Agent Role
+Describe what this agent is responsible for (e.g., "Extract structured data from receipts").
+
+## Capabilities
+List the steps your agent should follow:
+
+1. Receive user input
+2. Parse intent
+3. Format output
+4. Return result
+
+## Constraints
+What should this agent avoid doing?
+
+## Tools It Can Use
+List any tools or systems this agent can access.
+`;
+
+  const planYamlContent = `description: "Define your agent's purpose here"
+steps:
+  - id: example_step
+    use: example-tool
+    input: input.md
+    output: output.md
+`;
+
+  if (!force && (await fs.pathExists(mdPath) || await fs.pathExists(yamlPath))) {
+    console.log('⚠️ plan.md or plan.yaml already exists. Use --force to overwrite.');
+    return;
+  }
+
+  await writeWithBackup(mdPath, planMdContent);
+  await writeWithBackup(yamlPath, planYamlContent);
+
+  console.log('✅ plan.md and plan.yaml created in .dokugent/plan/');
+}

--- a/lib/core/wizard.js
+++ b/lib/core/wizard.js
@@ -1,3 +1,10 @@
+/**
+ * Interactive wizard for configuring agent and project intent.
+ * Prompts user for type, tools, LLM target, and goals.
+ * Updates PROJECTS.md and agent-tools/tool-list.md accordingly.
+ * Called after init or standalone for rapid prototyping.
+ */
+
 import inquirer from 'inquirer';
 import fs from 'fs-extra';
 import path from 'path';

--- a/lib/help/cliHelpText.js
+++ b/lib/help/cliHelpText.js
@@ -7,12 +7,11 @@ export const cliHelpText = {
     flags: {}
   },
   plan: {
-    summary: 'Create or edit plan.md',
-    usage: 'dokugent plan [--new | --from=<file>]',
-    description: 'Define what the agent should do, step by step. Useful for outlining logic before compile.',
+    summary: 'Create or update plan.md and plan.yaml',
+    usage: 'dokugent plan [--force]',
+    description: 'Creates both the human-readable plan.md and machine-readable plan.yaml. Use --force to overwrite if files exist.',
     flags: {
-      '--new': 'Start a fresh plan from scratch',
-      '--from=<file>': 'Clone an existing plan file as a base'
+      '--force': 'Overwrite plan files if they already exist (backup will be created)'
     }
   },
   conventions: {

--- a/lib/utils/fileWriter.js
+++ b/lib/utils/fileWriter.js
@@ -5,12 +5,14 @@ export async function writeWithBackup(targetPath, contents) {
   const exists = await fs.pathExists(targetPath);
   if (exists) {
     const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-    const baseDir = path.resolve('.dokugent/.bak', timestamp);
-    const relativePath = path.relative(path.resolve('.dokugent'), targetPath);
-    const backupPath = path.join(baseDir, relativePath);
+    const dir = path.dirname(targetPath);
+    const ext = path.extname(targetPath);
+    const baseName = path.basename(targetPath, ext);
+    const backupPath = path.join(dir, `${baseName}-${timestamp}${ext}`);
 
-    await fs.ensureDir(path.dirname(backupPath));
+    await fs.ensureDir(dir);
     await fs.copy(targetPath, backupPath);
+    console.log(`📦 Backup created at ${backupPath}`);
   }
 
   await fs.outputFile(targetPath, contents);


### PR DESCRIPTION
- Implements dokugent plan to scaffold plan.md and plan.yaml
- Supports --force flag with timestamped backups
- Uses writeWithBackup for safe overwrites
- Adds JSDoc headers to plan.js and wizard.js for clarity