### PR TITLE
feat(preview): add --agent and --variant support with token estimatio…

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ Instead of bloated repos or scattered prompts, Dokugent gives your AI teammates 
 
 While originally designed for developers, Dokugent’s modular structure can also support structured thinking in content planning, education, research, and more.
 
----
-
 ## 🚀 Features
 
 - 📁 Scaffolds agent projects with `init` and `wizard`
@@ -22,20 +20,10 @@ While originally designed for developers, Dokugent’s modular structure can als
 - 🔐 Certifies and simulates agent reasoning flows
 - 📦 Supports Claude, Codex, GPT-4, Gemini, LLaMA via `agents.yml`
 
----
-
 ## 🛠 Getting Started
 
 ```bash
 npm install -g dokugent
-```
-
-Then scaffold your first project:
-
-```bash
-dokugent init
-# then optionally
-dokugent wizard
 ```
 
 ---
@@ -57,21 +45,15 @@ dokugent wizard
 - `dokugent review` — checks trace output against expected behavior or goals
 - `dokugent keygen` — generates and stores API keys or access tokens
 
----
-
 ## 🧪 Coming Soon
 
 - `dokugent fetch` — download community-contributed agent plans and templates
-
----
 
 ## 🧱 Philosophy
 
 Dokugent embraces a protocol-first mindset for building intelligent systems. You don’t start by coding — you start by thinking, documenting, and aligning. This structure keeps your agents safe, traceable, and easy to reconfigure.
 
 With Dokugent, your documentation becomes a reusable memory scaffold.
-
----
 
 ## 📣 Trivia
 
@@ -82,8 +64,6 @@ Like **Goku**, but with **doku** — which in Japanese can mean either:
 
 Add **agent** and you get:
 **Dokugent = a reading agent…**
-
----
 
 ### 🌏 Multilingual roots
 
@@ -99,8 +79,6 @@ Add **agent** and you get:
 
 **Dokugent** is a portmanteau of all these — a cross-cultural nod to literacy, power, and intelligent agents.
 
----
-
 ## 🛡 License
 
 Dokugent is licensed under the [PolyForm Shield License 1.0.0](https://polyformproject.org/licenses/shield/1.0.0/).
@@ -108,4 +86,6 @@ Dokugent is licensed under the [PolyForm Shield License 1.0.0](https://polyformp
 ✅ Use it for personal projects, client work, or internal tooling  
 ❌ You can’t use it to build a competing product or service
 
-For commercial licensing or collaboration, feel free to reach out 💬
+---
+
+> 🧠 Built with agent token hygiene in mind.

--- a/bin/dokugent.js
+++ b/bin/dokugent.js
@@ -15,6 +15,7 @@ import { printHelp } from '../lib/help/cliHelpText.js';
 import { runPlan } from '../lib/core/plan.js';
 import { runCriteria } from '../lib/core/criteria.js';
 import { handleConventions } from '../lib/core/conventions.js';
+import { generatePreview } from '../lib/core/preview.js';
 
 const calledAs = process.argv[1]?.split('/').pop();
 if (calledAs === 'doku') {
@@ -82,6 +83,16 @@ program
   .option('--force', 'overwrite existing convention folder with backup')
   .action(async (type, options) => {
     await handleConventions({ type, force: options.force || false });
+  });
+
+program
+  .command('preview')
+  .description('Generate preview-plan.yaml and preview-conventions.md in .dokugent/preview')
+  .option('--agent <agent>', 'Specify agent profile (codex, gpt4, claude, llama, gemini, mistral, grok)')
+  .option('--variant <variant>', 'Specify agent variant (for multi-profile agents like gemini and mistral)')
+  .action(async (options) => {
+    await generatePreview(options.agent, options.variant);
+    console.log('✅ Preview files generated in .dokugent/preview');
   });
 
 program.parse(process.argv);

--- a/lib/config/agents.yaml
+++ b/lib/config/agents.yaml
@@ -1,0 +1,71 @@
+# agent.yml
+# Per-agent metadata and preferences for briefing formatting and ideal limits
+agents:
+  claude:
+    label: Claude 3
+    maxTokenLoad: 100000
+    idealBriefingSize: 8000
+    notes: >
+      Claude handles large contexts well but prefers well-structured, flat markdown with minimal recursion.
+  codex:
+    label: Codex CLI
+    maxTokenLoad: 4000
+    idealBriefingSize: 2000
+    notes: >
+      Codex prefers short code-oriented prompts. Strip prose-heavy files.
+  gpt4:
+    label: GPT-4 Turbo
+    maxTokenLoad: 128000
+    idealBriefingSize: 12000
+    notes: >
+      GPT-4 handles large input but may hallucinate under bloat. Focus on clarity over quantity.
+  gemini:
+    label: Gemini
+    defaultVariant: pro-1.5
+    variants:
+      pro-1.5:
+        label: Gemini 1.5 Pro
+        maxTokenLoad: 2097152
+        idealBriefingSize: 12000
+        notes: >
+          Optimized for long-context reasoning. Keep prompts structured.
+      flash-1.5:
+        label: Gemini 1.5 Flash
+        maxTokenLoad: 1048576
+        idealBriefingSize: 8000
+        notes: >
+          Prioritizes speed. Avoid verbose instructions.
+      pro-2.5:
+        label: Gemini 2.5 Pro
+        maxTokenLoad: 1048576
+        idealBriefingSize: 16000
+        notes: >
+          Enhanced output length. Use for summarization or report generation.
+  llama:
+    label: LLaMA 3
+    maxTokenLoad: 32000
+    idealBriefingSize: 6000
+    notes: >
+      Ideal for compact reasoning tasks. Strip all non-essential markdown decoration.
+  mistral:
+    label: Mistral
+    defaultVariant: 7b
+    variants:
+      7b:
+        label: Mistral 7B
+        maxTokenLoad: 32000
+        idealBriefingSize: 6000
+        notes: >
+          Good for lightweight tasks and tight loops. Focuses on speed and efficiency.
+      mixtral:
+        label: Mixtral 8x7B
+        maxTokenLoad: 32000
+        idealBriefingSize: 8000
+        notes: >
+          Better at diverse prompt styles. Use when tasks vary or need a broader reasoning range.
+  grok:
+    label: xAI Grok
+    maxTokenLoad: 128000
+    idealBriefingSize: 8000
+    notes: >
+      Grok is designed for contextual understanding and fast iteration. Structured Markdown helps, but it can handle natural language prompts well. Context limits and variant distinctions may evolve as the API matures.

--- a/lib/config/agentsConfig.js
+++ b/lib/config/agentsConfig.js
@@ -1,0 +1,18 @@
+import fs from 'fs-extra';
+import yaml from 'js-yaml';
+import path from 'path';
+import { fileURLToPath } from 'url';
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const AGENTS_YML_PATH = path.resolve(__dirname, 'agents.yaml');
+
+export async function getAgentProfiles() {
+  try {
+    const content = await fs.readFile(AGENTS_YML_PATH, 'utf8');
+    const data = yaml.load(content);
+    return data?.agents || {};
+  } catch (err) {
+    console.error('⚠️ Failed to load agents.yml:', err.message);
+    return {};
+  }
+}

--- a/lib/config/cliSpec.js
+++ b/lib/config/cliSpec.js
@@ -23,7 +23,7 @@ export const cliSpec = {
     },
     preview: {
       description: 'Render plan, conventions, and criteria for human review before compiling',
-      flags: ['--plan', '--conventions=<items>', '--criteria']
+      flags: ['--agent=<key>', '--variant=<key>']
     },
     security: {
       description: 'Validate against unsafe actions, tools, or behavior',

--- a/lib/core/preview.js
+++ b/lib/core/preview.js
@@ -1,0 +1,137 @@
+/**
+ * Generates a preview of Dokugent files for human inspection before compilation.
+ * Dumps validated plan and conventions into .dokugent/preview/ as formatted files.
+ * Designed as a preflight step to help users confirm structure and content.
+ */
+
+import fs from 'fs-extra'
+import path from 'path'
+import matter from 'gray-matter'
+import { fileURLToPath } from 'url'
+import { getAgentProfiles } from '../config/agentsConfig.js';
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+const dokugentPath = path.join(process.cwd(), '.dokugent')
+const previewPath = path.join(dokugentPath, 'preview')
+
+export async function generatePreview(agentKey, variantKey) {
+  await fs.ensureDir(previewPath)
+
+  const agents = await getAgentProfiles();
+  let activeAgent;
+  if (agentKey && !agents[agentKey]) {
+    console.log(`\n⚠️  Unknown agent: ${agentKey}. Falling back to default (Codex CLI).`);
+    console.log(`ℹ️  Tip: Run 'dokugent help preview' to see supported agents.\n`);
+    agentKey = 'codex';
+  }
+
+  const selected = agents[agentKey];
+  if (selected?.variants) {
+    if (!variantKey || !selected.variants[variantKey]) {
+      const variantList = Object.keys(selected.variants).join(' | ');
+      console.error(`\n⚠️ Missing or unknown variant. Use --variant ${variantList}`);
+      return;
+    }
+    activeAgent = selected.variants[variantKey];
+  } else {
+    activeAgent = selected || agents.codex || {};
+  }
+  const idealMaxTokens = activeAgent.idealBriefingSize || 4000;
+  const timestamp = new Date().toISOString()
+  const metadata = { previewed_by: 'dokugent', timestamp }
+  let totalTokens = 0
+
+  async function mergeMdFiles(srcFolder, outName) {
+    if (!(await fs.pathExists(srcFolder))) {
+      console.warn(`⚠️  Skipped: ${srcFolder} not found`)
+      return
+    }
+
+    let merged = ''
+
+    async function walkAndMerge(folder) {
+      const entries = await fs.readdir(folder, { withFileTypes: true })
+      for (const entry of entries) {
+        const fullPath = path.join(folder, entry.name)
+        if (entry.isDirectory()) {
+          await walkAndMerge(fullPath)
+        } else if (entry.isFile() && entry.name.endsWith('.md')) {
+          const content = await fs.readFile(fullPath, 'utf8')
+          merged += `\n\n# ${entry.name}\n\n${content}`
+        }
+      }
+    }
+
+    await walkAndMerge(srcFolder)
+
+    if (!merged.trim()) {
+      console.warn(`⚠️  Skipped: No .md files found recursively in ${srcFolder}`)
+      return
+    }
+
+    const output = matter.stringify(merged.trim(), metadata)
+    await fs.writeFile(path.join(previewPath, outName), output)
+    const estimatedTokens = Math.round(merged.trim().split(/\s+/).length * 1.33)
+    totalTokens += estimatedTokens
+    console.log(`✅ Wrote: ${outName} (${estimatedTokens} tokens est.)`)
+  }
+
+  async function copyYamlFile(srcFile, outName) {
+    if (!(await fs.pathExists(srcFile))) {
+      console.warn(`⚠️  Skipped: ${srcFile} not found`)
+      return
+    }
+    const content = await fs.readFile(srcFile, 'utf8')
+    await fs.writeFile(path.join(previewPath, outName), content)
+    const estimatedTokens = Math.round(content.trim().split(/\s+/).length * 1.33)
+    totalTokens += estimatedTokens
+    console.log(`✅ Wrote: ${outName} (${estimatedTokens} tokens est.)`)
+  }
+
+  async function copyAgentMdFiles(srcFolder) {
+    if (!(await fs.pathExists(srcFolder))) {
+      console.warn(`⚠️  Skipped: ${srcFolder} not found`)
+      return
+    }
+    const files = await fs.readdir(srcFolder)
+    for (const file of files) {
+      const ext = path.extname(file)
+      const base = path.basename(file, ext)
+      const source = path.join(srcFolder, file)
+      const target = path.join(previewPath, `preview-${base}${ext}`)
+      if (ext === '.md') {
+        const content = await fs.readFile(source, 'utf8')
+        const output = matter.stringify(content, metadata)
+        await fs.writeFile(target, output)
+        const estimatedTokens = Math.round(content.trim().split(/\s+/).length * 1.33)
+        totalTokens += estimatedTokens
+        console.log(`✅ Wrote: preview-${base}.md (${estimatedTokens} tokens est.)`)
+      } else if (ext === '.yaml' || ext === '.yml') {
+        await fs.copyFile(source, target)
+        console.log(`✅ Wrote: preview-${base}${ext}`)
+      }
+    }
+  }
+
+  await mergeMdFiles(path.join(dokugentPath, 'plan'), 'preview-plan.md')
+  await mergeMdFiles(path.join(dokugentPath, 'criteria'), 'preview-criteria.md')
+  await mergeMdFiles(path.join(dokugentPath, 'conventions', 'dev'), 'preview-conventions.md')
+  await copyYamlFile(path.join(dokugentPath, 'plan', 'plan.yaml'), 'preview-plan.yaml')
+  await copyYamlFile(path.join(dokugentPath, 'criteria', 'criteria.yaml'), 'preview-criteria.yaml')
+  await copyAgentMdFiles(path.join(dokugentPath, 'agent-tools'))
+
+  console.log(`\n🧠 Estimated Total Tokens: ${totalTokens}`);
+  console.log(`🎯 Agent: ${activeAgent.label || 'Codex'} (Max Token Load: ${activeAgent.maxTokenLoad || 'N/A'} tokens)`);
+
+  if (totalTokens > idealMaxTokens) {
+    console.warn(`⚠️ Over the ideal optimal size of ${idealMaxTokens} tokens — consider trimming files.`);
+  } else {
+    console.log(`✅ Within the ideal optimal size of ${idealMaxTokens} tokens.`);
+  }
+
+  if (activeAgent.notes) {
+    console.log(`🤖 ${activeAgent.notes.trim()}`);
+  }
+}

--- a/lib/help/cliHelpText.js
+++ b/lib/help/cliHelpText.js
@@ -31,13 +31,12 @@ export const cliHelpText = {
     }
   },
   preview: {
-    summary: 'Preview plan, conventions, and criteria before compiling',
-    usage: 'dokugent preview --plan --conventions --criteria',
-    description: 'Renders human-readable summaries of planning docs before compiling into a spec.',
+    summary: 'Preview merged files and estimate token usage',
+    usage: 'dokugent preview --agent <agent> [--variant <variant>]',
+    description: 'Merges plan, conventions, criteria, and tools into .dokugent/preview. Displays token estimates with guidance from the selected agent profile and variant (if applicable).',
     flags: {
-      '--plan': 'Path to the plan file',
-      '--conventions': 'Path to the conventions file',
-      '--criteria': 'Path to the criteria file'
+      '--agent <agent>': 'Specify agent profile to use (e.g., codex, gpt4, claude, llama, gemini, mistral)',
+      '--variant <variant>': 'Specify agent variant (e.g., pro-1.5, mixtral) for multi-variant agents'
     }
   },
   compile: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "commander": "^11.0.0",
         "fs-extra": "^11.1.1",
+        "gray-matter": "^4.0.3",
         "js-yaml": "^4.1.0"
       },
       "bin": {
@@ -30,6 +31,31 @@
         "node": ">=16"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/fs-extra": {
       "version": "11.3.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
@@ -47,6 +73,52 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+    },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/gray-matter/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/gray-matter/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -68,6 +140,43 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/universalify": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "commander": "^11.0.0",
     "fs-extra": "^11.1.1",
+    "gray-matter": "^4.0.3",
     "js-yaml": "^4.1.0"
   }
 }


### PR DESCRIPTION
…n and safety guidance

- enforced agent/variant validation with fallback warnings
- merged preview includes .md + .yaml files across plan, criteria, conventions, and agent-tools
- added token estimation with total + per-file logs
- mapped ideal vs max token load per agent via agents.yaml
- supports Codex, Claude, GPT-4, Gemini (1.5/Flash/2.5), LLaMA 3, Mistral (7B/Mixtral), Grok
- updated cliSpec.js and cliHelpText.js with agent/variant flags
- added dx warnings for missing or unknown variants
- soft fail for unknown agents with fallback to Codex