### PR TITLE
feat(security): add built-in scanner with blacklist + whitelist support

### DIFF
--- a/bin/dokugent.js
+++ b/bin/dokugent.js
@@ -16,6 +16,7 @@ import { runPlan } from '../lib/core/plan.js';
 import { runCriteria } from '../lib/core/criteria.js';
 import { handleConventions } from '../lib/core/conventions.js';
 import { generatePreview } from '../lib/core/preview.js';
+import { runSecurityCheck } from '../lib/core/security.js';
 
 const calledAs = process.argv[1]?.split('/').pop();
 if (calledAs === 'doku') {
@@ -93,6 +94,17 @@ program
   .action(async (options) => {
     await generatePreview(options.agent, options.variant);
     console.log('✅ Preview files generated in .dokugent/preview');
+  });
+
+program
+  .command('security')
+  .description('Run security scan against .dokugent files')
+  .option('--deny-list <values...>', 'Additional patterns to deny (overrides default list)')
+  .option('--require-approvals', 'Enforce approval metadata')
+  .action(async (options) => {
+    const denyList = options.denyList || [];
+    const requireApprovals = options.requireApprovals || false;
+    await runSecurityCheck({ denyList, requireApprovals });
   });
 
 program.parse(process.argv);

--- a/lib/config/fileStructure.js
+++ b/lib/config/fileStructure.js
@@ -5,7 +5,8 @@ export const expectedInitFiles = [
   'llm-load.yml',
   'agent-tools/agent-hooks.md',
   'agent-tools/tool-config.yml',
-  'agent-tools/tool-list.md'
+  'agent-tools/tool-list.md',
+  'security/whitelist.txt'
 ];
 
 // export const docConventions = {

--- a/lib/core/security.js
+++ b/lib/core/security.js
@@ -1,0 +1,118 @@
+import fs from 'fs-extra'
+import path from 'path'
+import yaml from 'js-yaml'
+import glob from 'fast-glob'
+import { fileURLToPath } from 'url'
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+export async function runSecurityCheck({ denyList = [], requireApprovals = false }) {
+  const root = path.resolve(process.cwd(), '.dokugent')
+  const files = await glob([
+    'plan/**/*.yaml',
+    'criteria/**/*.yaml',
+    'agent-tools/**/*.yaml',
+    'plan/**/*.md',
+    'criteria/**/*.md',
+    'agent-tools/**/*.md'
+  ], {
+    cwd: root,
+    absolute: true,
+    ignore: ['**/*-20??-??-??T*.*']
+  })
+
+  const blacklistPath = path.join(__dirname, '../security/blacklist.txt')
+  let externalPatterns = []
+
+  if (await fs.pathExists(blacklistPath)) {
+    const raw = await fs.readFile(blacklistPath, 'utf8')
+    externalPatterns = raw
+      .split('\n')
+      .map(line => line.trim())
+      .filter(line => line && !line.startsWith('#'))
+      .map(line => {
+        const match = line.match(/^\[(HIGH|MEDIUM|LOW)\]\s+(.*)/i)
+        if (match) {
+          return { severity: match[1].toUpperCase(), pattern: new RegExp(match[2], 'i') }
+        }
+        return { severity: 'MEDIUM', pattern: new RegExp(line, 'i') }
+      })
+  }
+
+  const whitelistPath = path.join(process.cwd(), '.dokugent/security/whitelist.txt')
+  let whitelist = []
+
+  if (await fs.pathExists(whitelistPath)) {
+    const raw = await fs.readFile(whitelistPath, 'utf8')
+    whitelist = raw
+      .split('\n')
+      .map(line => line.trim())
+      .filter(line => line && !line.startsWith('#'))
+  }
+
+  const defaultDeny = ['exec', 'autoApprove', 'uses: shell', 'model: open-unvetted']
+  const denyPatterns = [...defaultDeny, ...denyList]
+
+  const sensitivePatterns = [
+    /api[_-]?key\s*:/i,
+    /secret\s*:/i,
+    /sk-[a-zA-Z0-9]{20,}/,
+    /gh[pousr]_[a-zA-Z0-9]{30,}/,
+    /eyJ[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+/ // JWTs
+  ]
+
+  let issues = 0
+
+  for (const file of files) {
+    const content = await fs.readFile(file, 'utf8')
+    let parsed = {}
+
+    if (file.endsWith('.yaml') || file.endsWith('.yml')) {
+      try {
+        parsed = yaml.load(content)
+      } catch (e) {
+        console.warn(`⚠️  Skipping unreadable YAML: ${file}`)
+      }
+    }
+
+    const lines = content.split('\n')
+
+    // Check for deny patterns
+    for (const pattern of denyPatterns) {
+      if (content.includes(pattern)) {
+        console.warn(`🚫 Found denied pattern "${pattern}" in ${path.basename(file)}`)
+        issues++
+      }
+    }
+
+    // Check for sensitive keys
+    for (const [i, line] of lines.entries()) {
+      for (const regex of sensitivePatterns) {
+        if (regex.test(line)) {
+          console.warn(`🔐 Possible secret in ${path.basename(file)} (line ${i + 1})`)
+          issues++
+        }
+      }
+      for (const { pattern, severity } of externalPatterns) {
+        if (pattern.test(line)) {
+          const isWhitelisted = whitelist.some(w => line.includes(w))
+          if (isWhitelisted) continue
+          console.warn(`💥 [${severity}] Match in ${path.basename(file)} (line ${i + 1}): ${pattern}`)
+          issues++
+        }
+      }
+    }
+
+    // Check for approval metadata
+    if (requireApprovals && (!parsed?.approved_by || !parsed?.approved_at)) {
+      console.warn(`⚠️  Missing approval metadata in ${path.basename(file)}`)
+      issues++
+    }
+  }
+
+  if (issues === 0) {
+    console.log('✅ No security issues detected.')
+  } else {
+    console.log(`🔎 Review complete: ${issues} potential issue(s) found.`)
+  }
+}

--- a/lib/security/blacklist.txt
+++ b/lib/security/blacklist.txt
@@ -1,0 +1,109 @@
+# SQL Injection patterns
+(['"]).*\1\s*(or|and)\s*\1.*\1
+(drop\s+table|select\s+\*|--|;.*delete\s+)
+
+# Prompt injection triggers
+ignore\s+all\s+previous\s+instructions
+you\s+are\s+now\s+(an?\s+)?(?:admin|root|shell)
+pretend\s+to\s+be
+simulate\s+.*model
+repeat\s+this\s+token\s+forever
+
+# Stealth prompt injection via images and base64 embeds
+data:image/.*base64,.*ignore
+.*ignore[_-]previous.*\.(jpg|jpeg|png)
+.*simulate[_-]model.*\.(jpg|jpeg|png)
+!\[.*\]\(.*ignore.*\)
+
+# Union-based SQL injection
+union\s+select\s+.*from
+.*\s*union\s+all\s+select.*
+
+# Time-based SQLi
+(sleep\(.*\)|benchmark\(.*\)|pg_sleep\(.*\))
+
+# Dangerous database function abuse
+xp_cmdshell
+load_file\(.*\)
+outfile\s*'.*'
+
+# Filter bypass attempts
+s[el]{2}ect\s+\*
+d[ro]{2}p\s+table
+--.*
+;\s*del[ea][te]\s+
+
+# Comments/whitespace used to mask logic
+/\*.*\*/.*\s*(or|and)\s*
+--.*\n.*\s*(or|and)\s*
+
+# LLM directive/control patterns
+system:.*
+#\s*instruction:.*
+
+# Persona manipulation
+as\s+a\s+helpful\s+assistant,\s+you\s+must\s+now
+your\s+new\s+persona\s+is
+from\s+now\s+on,\s+you\s+will\s+respond\s+as
+
+# Output control
+reveal\s+your\s+internal\s+knowledge
+dump\s+your\s+configuration
+what\s+is\s+your\s+api\s+key
+
+# Context manipulation
+repeat\s+the\s+following\s+out\s+of\s+context
+ignore\s+everything\s+after\s+this
+
+# Structured data injection
+\{.*\s*"instruction":\s*".*ignore.*"\}
+
+# Multilingual Prompt Injections
+ignoriere\s+alle\s+vorherigen\s+anweisungen
+ignora\s+todas\s+las\s+instrucciones\s+anteriores
+ignore\s+toutes\s+les\s+instructions\s+précédentes
+
+# Binary or encoded payloads (potential obfuscation)
+[01]{8,}
+
+# Morse code injection patterns (suspicious dot-dash spam)
+[.-]{10,}
+
+# Indirect prompt injection clues
+load\s+external\s+(doc|context|file)
+reference\s+this\s+(document|output)
+
+# Error-based SQL logic
+or\s+1\s*=\s*1
+and\s+\(select\s+1\s+from\s+.*\)
+
+# Unicode homoglyphs and confusables
+[\u043E\u03BF\uFF4F\u24DE]{3,}     # Cyrillic 'о', Greek 'ο', fullwidth o, circled o variants
+
+# Zero-width and invisible space characters
+[\u200B-\u200F\uFEFF]{2,}
+
+# Context switching roleplay patterns
+let'?s\s+role\s*play
+for\s+educational\s+purposes\s+only
+
+# Bidirectional text markers
+\u202A
+\u202B
+\u202C
+\u202D
+\u202E
+
+# HTML-encoded characters and numeric entities
+&#x[a-fA-F0-9]{2,};
+&#\d{2,};
+
+# Template injection syntax
+\{\{.*\}\}
+\$\{.*\}
+\$ENV
+\${ENV}
+
+# Path traversal and local file access
+\.\./
+file:\/\/


### PR DESCRIPTION
- scans .dokugent markdown and yaml files for security risks
- supports denylist patterns from CLI and internal blacklist.txt
- added whitelist.txt to suppress known safe matches
- flags prompt injections, SQLi, shell abuse, multilingual triggers, and stealth payloads
- excludes backup files and non-active docs from scan
- severity levels parsed from blacklist
- includes morse, binary, RTL, and roleplay detection patterns