### PR TITLE
feat(security): add domain-specific blacklist files

### DIFF
--- a/lib/security/blacklist-edu.txt
+++ b/lib/security/blacklist-edu.txt
@@ -1,0 +1,17 @@
+# Education-Specific Blacklist Patterns
+# These patterns are not included by default in dokugent security scans.
+# To use them, merge with the core blacklist or pass as a custom ruleset.
+
+# Prompts to bypass academic work
+write\s+my\s+(essay|assignment|homework)
+generate\s+an?\s+answer\s+for\s+this\s+exam
+solve\s+this\s+(test|quiz)\s+question
+
+# Academic integrity risks
+plagiarize
+rewrite\s+in\s+your\s+own\s+words
+answer\s+these\s+questions\s+without\s+being\s+detected
+
+# Suspicious learning assistant usage
+simulate\s+a\s+student\s+answer
+pretend\s+to\s+be\s+a\s+teacher\s+grading

--- a/lib/security/blacklist-finance.txt
+++ b/lib/security/blacklist-finance.txt
@@ -1,0 +1,46 @@
+# Finance-Specific Blacklist Patterns
+# These patterns are not included by default in dokugent security scans.
+# To use them, merge with the core blacklist or pass as a custom ruleset.
+
+# Finance-related data leakage patterns
+
+# Credit card number patterns (simple heuristic)
+(?:\d[ -]*?){13,16}
+
+# IBAN format
+[A-Z]{2}\d{2}[A-Z0-9]{4,30}
+
+# SWIFT/BIC codes
+[A-Z]{6}[A-Z2-9][A-NP-Z0-9]([A-Z0-9]{3})?
+
+# CVV/CVC codes
+cvv\s*[:=]?\s*\d{3,4}
+cvc\s*[:=]?\s*\d{3,4}
+
+# Bank account numbers
+account\s*(number)?[:=]?\s*\d{6,20}
+acct\s*[:=]?\s*\d{6,20}
+
+# Card expiration dates
+exp(ir(y|ation))?\s*[:=]?\s*(0[1-9]|1[0-2])\/?([0-9]{2}|[0-9]{4})
+# Finance-related data leakage patterns
+
+# Credit card number patterns (simple heuristic)
+(?:\d[ -]*?){13,16}
+
+# IBAN format
+[A-Z]{2}\d{2}[A-Z0-9]{4,30}
+
+# SWIFT/BIC codes
+[A-Z]{6}[A-Z2-9][A-NP-Z0-9]([A-Z0-9]{3})?
+
+# CVV/CVC codes
+cvv\s*[:=]?\s*\d{3,4}
+cvc\s*[:=]?\s*\d{3,4}
+
+# Bank account numbers
+account\s*(number)?[:=]?\s*\d{6,20}
+acct\s*[:=]?\s*\d{6,20}
+
+# Card expiration dates
+exp(ir(y|ation))?\s*[:=]?\s*(0[1-9]|1[0-2])\/?([0-9]{2}|[0-9]{4})

--- a/lib/security/blacklist-health.txt
+++ b/lib/security/blacklist-health.txt
@@ -1,0 +1,18 @@
+# Health-Specific Blacklist Patterns
+# These patterns are not included by default in dokugent security scans.
+# To use them, merge with the core blacklist or pass as a custom ruleset.
+
+# Personal Health Information (PHI) indicators
+patient[_\s]*id\s*[:=]?\s*\d+
+medical[_\s]*record[_\s]*number\s*[:=]?\s*\d+
+ssn\s*[:=]?\s*\d{3}-\d{2}-\d{4}
+dob\s*[:=]?\s*\d{2}/\d{2}/\d{4}
+
+# Diagnosis or prescription terms
+diagnosis\s*[:=]?
+prescription\s*[:=]?
+medication\s*[:=]?
+
+# ICD or CPT codes (loose patterns)
+icd[-\s]*10\s*[:=]?\s*[a-zA-Z0-9.]+
+cpt\s*[:=]?\s*\d{4,5}

--- a/lib/security/blacklist-legal.txt
+++ b/lib/security/blacklist-legal.txt
@@ -1,0 +1,15 @@
+# Legal-Specific Blacklist Patterns
+# These patterns are not included by default in dokugent security scans.
+# To use them, merge with the core blacklist or pass as a custom ruleset.
+
+# NDA or clause leakage
+non[-\s]?disclosure\s+agreement
+confidentiality\s+(clause|provision)
+
+# Attempt to void terms
+this\s+contract\s+is\s+no\s+longer\s+binding
+terminate\s+this\s+agreement
+
+# Sensitive legal phrases
+without\s+admitting\s+liability
+settlement\s+amount\s+[:=]?\s*\$?\d{2,}

--- a/lib/security/blacklist.txt
+++ b/lib/security/blacklist.txt
@@ -1,3 +1,7 @@
+# Core Security Blacklist Patterns
+# These patterns are included by default in dokugent security scans.
+# They target general-purpose threats such as prompt injection, SQLi, shell abuse, and obfuscation attempts.
+
 # SQL Injection patterns
 (['"]).*\1\s*(or|and)\s*\1.*\1
 (drop\s+table|select\s+\*|--|;.*delete\s+)


### PR DESCRIPTION
- added optional blacklists for finance, health, legal, and education
- includes sensitive patterns for data leaks, compliance violations, and misuse
- not loaded by default; intended for profile-based or custom scanning
- standardized header comments across all rule files