### PR TITLE
feat(core): add agentSpec support with preview fallback and keygen

### DIFF
--- a/bin/dokugent.js
+++ b/bin/dokugent.js
@@ -17,6 +17,7 @@ import { runCriteria } from '../lib/core/criteria.js';
 import { handleConventions } from '../lib/core/conventions.js';
 import { generatePreview } from '../lib/core/preview.js';
 import { runSecurityCheck } from '../lib/core/security.js';
+import { generateKeyPair } from '../lib/core/keygen.js';
 
 const calledAs = process.argv[1]?.split('/').pop();
 if (calledAs === 'doku') {
@@ -105,6 +106,14 @@ program
     const denyList = options.denyList || [];
     const requireApprovals = options.requireApprovals || false;
     await runSecurityCheck({ denyList, requireApprovals });
+  });
+
+program
+  .command('keygen')
+  .description('Generate a private/public key pair for signing')
+  .option('--name <id>', 'Key name (used for filename)', 'agent')
+  .action(async (options) => {
+    await generateKeyPair(options.name);
   });
 
 program.parse(process.argv);

--- a/lib/config/fileStructure.js
+++ b/lib/config/fileStructure.js
@@ -6,7 +6,8 @@ export const expectedInitFiles = [
   'agent-tools/agent-hooks.md',
   'agent-tools/tool-config.yml',
   'agent-tools/tool-list.md',
-  'security/whitelist.txt'
+  'security/whitelist.txt',
+  'agent/agentSpec.mjs'
 ];
 
 // export const docConventions = {

--- a/lib/core/keygen.js
+++ b/lib/core/keygen.js
@@ -1,0 +1,32 @@
+
+
+import fs from 'fs-extra'
+import path from 'path'
+import crypto from 'node:crypto'
+
+export async function generateKeyPair(name = 'agent') {
+  const keyDir = path.resolve(process.cwd(), '.dokugent/keys')
+  await fs.ensureDir(keyDir)
+
+  const { publicKey, privateKey } = crypto.generateKeyPairSync('rsa', {
+    modulusLength: 2048,
+    publicKeyEncoding: {
+      type: 'spki',
+      format: 'pem'
+    },
+    privateKeyEncoding: {
+      type: 'pkcs8',
+      format: 'pem'
+    }
+  })
+
+  const pubPath = path.join(keyDir, `${name}.public.pem`)
+  const privPath = path.join(keyDir, `${name}.private.pem`)
+
+  await fs.writeFile(pubPath, publicKey)
+  await fs.writeFile(privPath, privateKey)
+
+  console.log(`🔐 Key pair generated:`)
+  console.log(`- Public: ${pubPath}`)
+  console.log(`- Private: ${privPath}`)
+}

--- a/lib/core/preview.js
+++ b/lib/core/preview.js
@@ -9,6 +9,7 @@ import path from 'path'
 import matter from 'gray-matter'
 import { fileURLToPath } from 'url'
 import { getAgentProfiles } from '../config/agentsConfig.js';
+import yaml from 'js-yaml';
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -115,12 +116,46 @@ export async function generatePreview(agentKey, variantKey) {
     }
   }
 
+  async function previewAgentSpecYaml() {
+    const specYamlPath = path.join(dokugentPath, 'agent', 'agentSpec.yaml')
+    const specJsPath = path.join(dokugentPath, 'agent', 'agentSpec.mjs')
+    const outPath = path.join(previewPath, 'preview-agent-spec.md')
+
+    let content = ''
+    if (await fs.pathExists(specYamlPath)) {
+      content = await fs.readFile(specYamlPath, 'utf8')
+    } else if (await fs.pathExists(specJsPath)) {
+      try {
+        const jsSpecModule = await import(specJsPath)
+        const spec = jsSpecModule?.agentSpec || jsSpecModule.default
+        if (!spec) {
+          console.warn(`⚠️  Found ${specJsPath} but no export named agentSpec or default.`)
+          return
+        }
+        content = yaml.dump(spec)
+      } catch (err) {
+        console.warn(`⚠️  Failed to import agentSpec.js: ${err.message}`)
+        return
+      }
+    } else {
+      console.warn(`⚠️  Skipped: ${specYamlPath} not found and no agentSpec.js fallback.`)
+      return
+    }
+
+    const output = matter.stringify(content.trim(), metadata)
+    await fs.writeFile(outPath, output)
+    const estimatedTokens = Math.round(content.trim().split(/\s+/).length * 1.33)
+    totalTokens += estimatedTokens
+    console.log(`✅ Wrote: preview-agent-spec.md (${estimatedTokens} tokens est.)`)
+  }
+
   await mergeMdFiles(path.join(dokugentPath, 'plan'), 'preview-plan.md')
   await mergeMdFiles(path.join(dokugentPath, 'criteria'), 'preview-criteria.md')
   await mergeMdFiles(path.join(dokugentPath, 'conventions', 'dev'), 'preview-conventions.md')
   await copyYamlFile(path.join(dokugentPath, 'plan', 'plan.yaml'), 'preview-plan.yaml')
   await copyYamlFile(path.join(dokugentPath, 'criteria', 'criteria.yaml'), 'preview-criteria.yaml')
   await copyAgentMdFiles(path.join(dokugentPath, 'agent-tools'))
+  await previewAgentSpecYaml()
 
   console.log(`\n🧠 Estimated Total Tokens: ${totalTokens}`);
   console.log(`🎯 Agent: ${activeAgent.label || 'Codex'} (Max Token Load: ${activeAgent.maxTokenLoad || 'N/A'} tokens)`);

--- a/presets/templates/agent/agentSpec.mjs
+++ b/presets/templates/agent/agentSpec.mjs
@@ -1,0 +1,25 @@
+// Starter agent spec definition for reuse during init and as a source of truth
+export const agentSpec = {
+  name: "figobot",
+  description: "Extract and transform Figma form components into CMS-ready blocks",
+  roles: {
+    transformer: "Converts Figma nodes into structured export formats",
+    validator: "Ensures block output follows CMS requirements"
+  },
+  protocols: ["design-intent", "form-export", "cms-syntax"],
+  constraints: [
+    "Never modify layout nodes directly",
+    "Avoid unvalidated CSS injection",
+    "Do not emit comments unless instructed"
+  ],
+  outputs: ["JSON", "HTML", "markdown", "compressed-preview"],
+  capabilities: {
+    understands: ["Figma schema", "block-based CMS structure"],
+    tools: ["figma.getCurrentPage", "figma.getNodeById", "figma.notify"]
+  },
+  security: {
+    allowExternalFiles: false,
+    enforceApproval: true,
+    denyList: ["blacklist-health.txt"]
+  }
+};


### PR DESCRIPTION
- added .dokugent/agent/agentSpec.mjs as agent identity contract
- preview now generates preview-agent-spec.md from YAML or JS fallback
- integrated token estimation for agentSpec output
- added keygen command to generate RSA keypairs in .dokugent/keys
- updated preview to suppress dynamic import warnings with .mjs handling