### PR TITLE
feat(certify): warn on empty files and set .cert.* as read-only

### DIFF
--- a/lib/core/certify.js
+++ b/lib/core/certify.js
@@ -376,6 +376,55 @@ export async function certify({ key, name, output = 'beta' }) {
   const reportDest = path.join(certifiedDir, reportFileName);
   fs.copyFileSync(reportPath, reportDest);
 
+  // Snapshot each preview file as a .cert.md alongside the originals
+  for (const file of previewFilesToCopy) {
+    if (file.endsWith('.md')) {
+      const src = path.join(previewDir, file);
+      const content = fs.readFileSync(src, 'utf8').trim();
+      if (!content) {
+        console.warn(`⚠️ Skipping empty file: ${file}`);
+        continue;
+      }
+      const cleanName = file.replace(/^preview-/, '').replace(/\.md$/, '.cert.md');
+      const snapshotDest = path.join(certifiedDir, cleanName);
+      fs.writeFileSync(snapshotDest, content, 'utf8');
+      fs.chmodSync(snapshotDest, 0o444); // Set file to read-only (r--r--r--)
+    }
+  }
+
+  // Snapshot each preview file as a .cert.yaml or .cert.yml
+  for (const file of previewFilesToCopy) {
+    if (file.endsWith('.yaml') || file.endsWith('.yml')) {
+      const src = path.join(previewDir, file);
+      const content = fs.readFileSync(src, 'utf8').trim();
+      if (!content) {
+        console.warn(`⚠️ Skipping empty file: ${file}`);
+        continue;
+      }
+      const ext = path.extname(file);
+      const cleanName = file.replace(/^preview-/, '').replace(ext, `.cert${ext}`);
+      const snapshotDest = path.join(certifiedDir, cleanName);
+      fs.writeFileSync(snapshotDest, content, 'utf8');
+      fs.chmodSync(snapshotDest, 0o444); // Set file to read-only (r--r--r--)
+    }
+  }
+
+  // Snapshot each preview file as a .cert.mjs
+  for (const file of previewFilesToCopy) {
+    if (file.endsWith('.mjs')) {
+      const src = path.join(previewDir, file);
+      const content = fs.readFileSync(src, 'utf8').trim();
+      if (!content) {
+        console.warn(`⚠️ Skipping empty file: ${file}`);
+        continue;
+      }
+      const cleanName = file.replace(/^preview-/, '').replace(/\.mjs$/, '.cert.mjs');
+      const snapshotDest = path.join(certifiedDir, cleanName);
+      fs.writeFileSync(snapshotDest, content, 'utf8');
+      fs.chmodSync(snapshotDest, 0o444); // Set file to read-only (r--r--r--)
+    }
+  }
+
   // Create or update symlink with dynamic label
   const symlinkPath = path.join('certified', label);
   try {

--- a/lib/parsers/parseMarkdownSections.js
+++ b/lib/parsers/parseMarkdownSections.js
@@ -1,0 +1,45 @@
+
+
+import fs from 'fs';
+
+/**
+ * Parses a markdown file and returns an object where each top-level header (## or #) becomes a key,
+ * and its associated content becomes the value.
+ * 
+ * Example:
+ * ## Plan
+ * - Step 1
+ * - Step 2
+ * 
+ * Returns:
+ * {
+ *   Plan: "- Step 1\n- Step 2"
+ * }
+ */
+export function parseMarkdownSections(filePath) {
+  const content = fs.readFileSync(filePath, 'utf8');
+  const lines = content.split('\n');
+
+  const sections = {};
+  let currentHeader = null;
+  let buffer = [];
+
+  for (const line of lines) {
+    const headerMatch = line.match(/^(#{1,6})\s+(.*)$/);
+    if (headerMatch) {
+      if (currentHeader) {
+        sections[currentHeader] = buffer.join('\n').trim();
+      }
+      currentHeader = headerMatch[2].trim();
+      buffer = [];
+    } else if (currentHeader) {
+      buffer.push(line);
+    }
+  }
+
+  if (currentHeader) {
+    sections[currentHeader] = buffer.join('\n').trim();
+  }
+
+  return sections;
+}


### PR DESCRIPTION
- Skip snapshotting if preview file is empty
- Log warning for each empty file skipped
- Apply to .md, .yaml/.yml, and .mjs file types
- Enforce read-only permissions (chmod 444) on all .cert.* files