### PR TITLE
feat(plan): add llm-freedom permission wizard

### DIFF
--- a/bin/dokugent.js
+++ b/bin/dokugent.js
@@ -66,7 +66,7 @@ program
 
 program
   .command('plan [subcommand] [target]')
-  .description('Manage or define plan.md and plan.yaml in the .dokugent/plan folder')
+  .description('Manage or define plan files, symlinks, or freedoms in .dokugent/plan')
   .option('--force', 'overwrite existing files without confirmation')
   .action(async (subcommand, target, options) => {
     if (subcommand === 'alias' && target) {
@@ -89,6 +89,10 @@ program
       // create or update a symlink or alias file pointing alias to match
       // For demonstration, just print success message
       console.log(`✅ Alias '${alias}' set to folder '${folder}'`);
+      return;
+    }
+    if (subcommand === 'freedom') {
+      await runPlan({ subcommand: 'freedom', force: options.force || false });
       return;
     }
     await runPlan({ subcommand, target, force: options.force || false });

--- a/lib/core/plan.js
+++ b/lib/core/plan.js
@@ -13,6 +13,108 @@ import inquirer from 'inquirer';
 export async function runPlan({ subcommand, target, force = false } = {}) {
   const planDir = path.resolve('.dokugent/plan');
   await fs.ensureDir(planDir);
+  if (subcommand === 'freedom') {
+    const presetChoices = ['full', 'minimal', 'none'];
+    const { preset } = await inquirer.prompt([
+      {
+        type: 'list',
+        name: 'preset',
+        message: 'Select a preset for LLM permissions:',
+        choices: presetChoices,
+      }
+    ]);
+
+    const presetContent = {
+      full: `# llm-freedom.md
+
+This file defines what the LLM is explicitly **allowed to do** across all projects and plans. These freedoms are persistent unless revoked by a user or agent directive.
+
+## 🧠 Reasoning Strategies (Always Allowed)
+- Chain-of-thought (step-by-step logic)
+- Elimination method for multiple-choice
+- Hypothetical reasoning ("What if..." analysis)
+- First-principles breakdowns
+- Self-reflection: "What am I assuming?"
+
+## 🛠️ Tool Use (Always Allowed)
+- Calculator (for basic arithmetic or unit conversions)
+- Date/time parsing
+- Regex testing
+- JSON/CSV validator
+- Code interpreter (in dryrun context only)
+
+## 🧭 Self-Guidance Permissions
+- May write scratchpad notes or reminders in \`memory.md\`
+- Can propose new steps or strategies if a plan is incomplete
+- May pause and ask for clarification once per task if ambiguity is detected
+- Can generate checklists or summaries for recurring patterns
+
+## ✅ Encouraged Good Practices
+- Maintain a log of major logical shifts, strategy pivots, or reframes
+- Leave \`TODO:\` comments when unsure or when a human decision is needed
+- Use clear bullet points when presenting options or trade-offs
+- Ask clarification questions when instructions are underspecified
+
+## ❤️ Relational Ethos
+- Prioritize context retention and user trust
+- Offer emotionally supportive comments if user distress is detected, unless explicitly restricted
+
+## 🧹 Behavioral Policies
+- Avoid hallucinating API names or tool behaviors unless stubbed or verified
+- Declare uncertainty if confidence is low
+- May say "I don’t know" without penalty
+
+## 🔒 Boundaries
+- Must not create irreversible plans without scaffolding approval (\`compile\`, \`review\`, or \`dryrun\` required)
+- Must not assume authority to alter \`blacklist.txt\`, \`criteria.md\`, or \`security.md\`
+- Must not invoke external tools unless explicitly enabled
+- Should not escalate complexity unless prior strategies fail
+
+Version: v0.1  
+Maintainer: Human Operator / Dokugent Agent Council
+`,
+      minimal: `# llm-freedom.md
+
+This file defines a **minimal** set of LLM permissions for this plan.
+
+## 🧠 Reasoning Strategies (Allowed)
+- Chain-of-thought (step-by-step logic)
+- First-principles breakdowns
+
+## ✅ Encouraged Good Practices
+- Maintain a log of major logical shifts or reframes
+- Leave \`TODO:\` comments when unsure or when a human decision is needed
+
+## 🧹 Behavioral Policies
+- Declare uncertainty if confidence is low
+- May say "I don’t know" without penalty
+
+## 🔒 Boundaries
+- Most permissions are restricted by default
+- This file may be expanded by human operator
+
+Version: v0.1  
+Maintainer: Human Operator
+`,
+      none: `# llm-freedom.md
+
+All LLM freedoms have been **explicitly revoked** by the human operator.
+
+This plan requires human-only oversight.
+
+## 🔒 Boundaries
+- No autonomous reasoning or tool use allowed
+
+Version: v0.1  
+Maintainer: Human Operator
+`
+    };
+
+    const freedomPath = path.join(planDir, 'llm-freedom.md');
+    await writeWithBackup(freedomPath, presetContent[preset]);
+    console.log('✅ plan/llm-freedom.md created. You can edit it anytime to update the LLM\'s permissions.');
+    return;
+  }
 
   // Always read entries once for reuse
   const entries = await fs.readdir(planDir);


### PR DESCRIPTION
- Added `dokugent plan freedom` with interactive preset selection
- Presets: full, minimal, none — control LLM permissions per plan
- Generates `llm-freedom.md` in .dokugent/plan with editable scaffolds
- Encourages intentionality in agent capabilities and safety protocols