### PR TITLE
refactor(plan): use shared version resolver for plan use

### DIFF
--- a/lib/core/plan.js
+++ b/lib/core/plan.js
@@ -9,6 +9,7 @@ import fs from 'fs-extra';
 import path from 'path';
 import { writeWithBackup } from '../utils/fileWriter.js';
 import inquirer from 'inquirer';
+import { resolveVersionedPath } from '../utils/resolveVersionedPath.js';
 
 export async function runPlan({ subcommand, target, force = false } = {}) {
   const planDir = path.resolve('.dokugent/plan');
@@ -207,17 +208,17 @@ Maintainer: Human Operator
       return;
     }
 
-    const candidates = await fs.readdir(planDir);
-    const match = candidates.find(f => f.startsWith(`${stepId}-${version}`));
-    if (!match) {
+    const resolvedPath = resolveVersionedPath(planDir, `${stepId}@${version}`);
+    const folderName = path.basename(resolvedPath);
+    if (!fs.existsSync(resolvedPath)) {
       console.error(`❌ No matching plan found for ${stepId}@${version}`);
       return;
     }
 
     const symlinkPath = path.join(planDir, stepId);
     try { await fs.remove(symlinkPath); } catch { }
-    await fs.symlink(path.join(planDir, match), symlinkPath, 'dir');
-    console.log(`🔗 Symlink updated: ${stepId} → ${match}`);
+    await fs.symlink(resolvedPath, symlinkPath, 'dir');
+    console.log(`🔗 Symlink updated: ${stepId} → ${folderName}`);
     return;
   }
 

--- a/lib/utils/resolveVersionedPath.js
+++ b/lib/utils/resolveVersionedPath.js
@@ -1,0 +1,36 @@
+import fs from "fs";
+import path from "path";
+
+/**
+ * Resolves the actual folder path of a versioned stepId.
+ * Example: "myStep@20240513" → resolves to baseDir/myStep@20240513
+ * Falls back to latest version or baseDir/myStep if not found.
+ *
+ * @param {string} baseDir - The directory where versioned steps are located.
+ * @param {string} stepIdWithVersion - A string like "myStep@20240513" or just "myStep".
+ * @returns {string} - The resolved absolute path.
+ */
+export function resolveVersionedPath(baseDir, stepIdWithVersion) {
+  const [stepId, version] = stepIdWithVersion.split("@");
+  const versionedDir = version ? `${stepId}@${version}` : null;
+
+  if (versionedDir) {
+    const fullPath = path.resolve(baseDir, versionedDir);
+    if (fs.existsSync(fullPath)) return fullPath;
+  }
+
+  // fallback: get most recent matching folder
+  const allEntries = fs.readdirSync(baseDir, { withFileTypes: true });
+  const matching = allEntries
+    .filter((e) => e.isDirectory() && e.name.startsWith(`${stepId}@`))
+    .map((e) => e.name)
+    .sort()
+    .reverse(); // latest first by default string sort
+
+  if (matching.length > 0) {
+    return path.resolve(baseDir, matching[0]);
+  }
+
+  // fallback to non-versioned path
+  return path.resolve(baseDir, stepId);
+}


### PR DESCRIPTION
- Extracted version resolution logic into utils/resolveVersionedPath.js
- Replaced inline plan use folder lookup with call to resolver
- Supports nvm-style stepId@version fallback logic
- Enables future reuse across conventions, criteria, and compile