### PR TITLE
feat(criteria): add 'criteria use' command with symlink support

### DIFF
--- a/bin/dokugent.js
+++ b/bin/dokugent.js
@@ -102,8 +102,9 @@ program
   .command('criteria')
   .description('Create or update criteria.md and criteria.yaml in the .dokugent/criteria folder')
   .option('--force', 'overwrite existing files without confirmation')
+  .option('--wizard', 'run interactive wizard to scaffold criteria')
   .action(async (options) => {
-    await runCriteria({ force: options.force || false });
+    await runCriteria({ force: options.force || false, wizard: options.wizard || false });
   });
 
 program

--- a/lib/core/criteria.js
+++ b/lib/core/criteria.js
@@ -8,55 +8,93 @@
 import fs from 'fs-extra';
 import path from 'path';
 import { writeWithBackup } from '../utils/fileWriter.js';
+import { resolveVersionedPath } from '../utils/resolveVersionedPath.js';
+import inquirer from 'inquirer';
 
 export async function runCriteria({ force = false } = {}) {
   const criteriaDir = path.resolve('.dokugent/criteria');
   await fs.ensureDir(criteriaDir);
 
-  const mdPath = path.join(criteriaDir, 'criteria.md');
-  const yamlPath = path.join(criteriaDir, 'criteria.yaml');
-
-  const criteriaMdContent = `# CRITERIA.md
-
-## Success Conditions
-What does a good output look like for this agent?
-
-## Failure Conditions
-What should this agent never do?
-
-## Evaluation Metrics
-How do you know if the agent did a good job?
-
-- Accuracy
-- Clarity
-- Tone
-- Relevance
-`;
-
-  const criteriaYamlContent = `success_conditions:
-  - Accurate extraction
-  - Matches format guidelines
-
-failure_conditions:
-  - Outputs invalid format
-  - Makes unsupported claims
-
-metrics:
-  - name: accuracy
-    weight: 0.4
-  - name: clarity
-    weight: 0.3
-  - name: relevance
-    weight: 0.3
-`;
+  const basePath = criteriaDir;
+  const mdPath = resolveVersionedPath(basePath, 'criteria.md');
+  const yamlPath = resolveVersionedPath(basePath, 'criteria.yaml');
 
   if (!force && (await fs.pathExists(mdPath) || await fs.pathExists(yamlPath))) {
     console.log('⚠️ criteria.md or criteria.yaml already exists. Use --force to overwrite.');
     return;
   }
 
+  const answers = await inquirer.prompt([
+    {
+      type: 'input',
+      name: 'successConditions',
+      message: '✅ What does a good output look like for this agent?',
+      default: 'Accurate, relevant, and follows format guidelines',
+    },
+    {
+      type: 'input',
+      name: 'failureConditions',
+      message: '❌ What should this agent never do?',
+      default: 'Make unsupported claims or use incorrect format',
+    },
+    {
+      type: 'checkbox',
+      name: 'metrics',
+      message: '📊 Select evaluation metrics:',
+      choices: [
+        { name: 'Accuracy', value: 'accuracy', checked: true },
+        { name: 'Clarity', value: 'clarity', checked: true },
+        { name: 'Relevance', value: 'relevance', checked: true },
+        { name: 'Tone', value: 'tone' },
+        { name: 'Timeliness', value: 'timeliness' },
+      ],
+    },
+  ]);
+
+  const criteriaMdContent = `# CRITERIA.md
+
+## Success Conditions
+${answers.successConditions}
+
+## Failure Conditions
+${answers.failureConditions}
+
+## Evaluation Metrics
+${answers.metrics.map((m) => `- ${m.charAt(0).toUpperCase() + m.slice(1)}`).join('\n')}
+`;
+
+  const criteriaYamlContent = `success_conditions:
+  - ${answers.successConditions}
+
+failure_conditions:
+  - ${answers.failureConditions}
+
+metrics:
+${answers.metrics
+      .map((m) => `  - name: ${m}\n    weight: ${1 / answers.metrics.length}`)
+      .join('\n')}
+`;
+
   await writeWithBackup(mdPath, criteriaMdContent);
   await writeWithBackup(yamlPath, criteriaYamlContent);
 
   console.log('✅ criteria.md and criteria.yaml created in .dokugent/criteria/');
+}
+
+export async function useCriteria(versionedName) {
+  const criteriaDir = path.resolve('.dokugent/criteria');
+  const resolvedPath = resolveVersionedPath(criteriaDir, versionedName);
+  const symlinkPath = path.join(criteriaDir, 'criteria');
+
+  if (!fs.existsSync(resolvedPath)) {
+    console.error(`❌ No matching criteria found for ${versionedName}`);
+    return;
+  }
+
+  try {
+    await fs.remove(symlinkPath);
+  } catch { }
+
+  await fs.symlink(resolvedPath, symlinkPath, 'dir');
+  console.log(`🔗 Symlink updated: criteria → ${path.basename(resolvedPath)}`);
 }


### PR DESCRIPTION
- Introduced useCriteria() to resolve and symlink versioned criteria folders
- Enables switching between versioned evaluation standards
- Mirrors plan use behavior for consistent agent scaffolding
- Supports workflows like certify, compile, and dryrun