### PR TITLE
fix(preview-ls): exclude SHA file from read-only and integrity checks

### DIFF
--- a/lib/utils/preview-ls.js
+++ b/lib/utils/preview-ls.js
@@ -24,23 +24,28 @@ export async function previewLs() {
 
   const entries = await fs.readdir(previewPath);
   let allGood = true;
+  let failedFiles = [];
 
   for (const entry of entries) {
     const fullPath = path.join(previewPath, entry);
     const stat = await fs.stat(fullPath);
     if (!stat.isFile()) continue;
 
+    if (entry === 'preview.sha256') {
+      continue;
+    }
+
     const isReadonly = !(stat.mode & 0o222);
     const buf = await fs.readFile(fullPath);
     const actualSha = crypto.createHash('sha256').update(buf).digest('hex');
     const expectedSha = expectedShas[entry];
-
     const shaMatch = expectedSha === actualSha;
     const roMark = isReadonly ? '✓ read-only' : '✗ not read-only';
-    const shaMark = expectedSha ? (shaMatch ? '✓ SHA match' : '✗ SHA mismatch') : '✗ SHA missing';
+    const shaMark = expectedSha
+      ? (shaMatch ? '✓ SHA match' : '✗ SHA mismatch')
+      : '✗ SHA missing';
 
-    if (!isReadonly || !shaMatch) allGood = false;
-
+    if (!isReadonly || !shaMatch) failedFiles.push(entry);
     console.log(`${(isReadonly && shaMatch ? '✅' : '⚠️')} ${entry} (${roMark}, ${shaMark})`);
   }
 
@@ -48,9 +53,9 @@ export async function previewLs() {
     console.log(`\n🧾 SHA file: preview.sha256 (${Object.keys(expectedShas).length} entries)`);
   }
 
-  if (allGood) {
-    console.log('\n🔒 All files intact and verified.');
+  if (failedFiles.length > 0) {
+    console.log(`\n❗ ${failedFiles.length} file(s) failed read-only or SHA check.`);
   } else {
-    console.log('\n❗Some preview files failed integrity or permission checks.');
+    console.log('\n🔒 All preview files passed integrity and permission checks.');
   }
 }


### PR DESCRIPTION
- Fully excluded preview.sha256 from SHA matching and chmod evaluation
- Removed misleading SHA missing warning for the system file
- Cleaned up final output to only reflect source content integrity
- Result: accurate pass/fail messaging with zero false alerts